### PR TITLE
esp32_i2c: allow to read many bytes

### DIFF
--- a/hw/i2c/esp32_i2c.c
+++ b/hw/i2c/esp32_i2c.c
@@ -210,8 +210,15 @@ static void esp32_i2c_do_transaction(Esp32I2CState * s)
                 break;
             }
             case I2C_OPCODE_READ: {
-                uint8_t data = i2c_recv(s->bus);
-                fifo8_push(&s->rx_fifo, data);
+                size_t length = FIELD_EX32(cmd, I2C_CMD, BYTE_NUM);
+                for (size_t nbytes = 0; nbytes < length; ++nbytes) {
+                    if (fifo8_num_free(&s->rx_fifo) == 0) {
+                        error_report("esp32_i2c: write to I2C RX FIFO while it is full");
+                    } else {
+                        uint8_t data = i2c_recv(s->bus);
+                        fifo8_push(&s->rx_fifo, data);
+                    }
+                }
                 break;
             }
             case I2C_OPCODE_STOP:


### PR DESCRIPTION
Hi There!

The pull request provides a fix that solves a problem of reading a few bytes at once (as one transaction) from an emulated i2c device

I encountered the problem during using the example "i2c_tools".
Consider the following i2c-tools cmd:
```
i2c-tools> i2cget -c 0x48 -r 0x00 -l 0x05
0x19 0xee 0xee 0xee 0x00 
i2c-tools> 
```

There is an error on stdout/stderr of the qemu during performing above cmd:
```
qemu-system-xtensa: esp32_i2c: read I2C FIFO while it is empty
qemu-system-xtensa: esp32_i2c: read I2C FIFO while it is empty
qemu-system-xtensa: esp32_i2c: read I2C FIFO while it is empty
```


Response after applying my changes
```
i2c-tools> i2cget -c 0x48 -r 0x00 -l 0x05
0x19 0x00 0xff 0xff 0xff 
i2c-tools> 
```
No error on QEMU stdout/stderr. Got expected result, emulated TMP105 returns 0xff when i2c master wants to read more than two bytes

If you need more info, let me know.


Best regards,
Karol