### PR TITLE
hw/xtensa: build fixes for building on 32 bit x86/arm

### DIFF
--- a/hw/xtensa/esp32.c
+++ b/hw/xtensa/esp32.c
@@ -275,6 +275,7 @@ static void esp32_soc_realize(DeviceState *dev, Error **errp)
     MemoryRegion *rtcfast_d = g_new(MemoryRegion, 1);
 
     for (int i = 0; i < ms->smp.cpus; ++i) {
+        assert(i >= 0 && i <= 9);
         MemoryRegion *drom = g_new(MemoryRegion, 1);
         MemoryRegion *irom = g_new(MemoryRegion, 1);
 


### PR DESCRIPTION
I tried to build qemu esp32 latest tag/release on a linux 32 bit x86 docker and on a raspberry pi with 32 bit os and it failed with

```
../hw/xtensa/esp32.c: In function 'esp32_soc_realize':
../hw/xtensa/esp32.c:282:53: error: '%d' directive output may be truncated writing between 1 and 8 bytes into a region of size 2 [-Werror=format-truncation=]
  282 |         snprintf(name, sizeof(name), "esp32.irom.cpu%d", i);
      |                                                     ^~
../hw/xtensa/esp32.c:282:38: note: directive argument in the range [0, 27531842]
  282 |         snprintf(name, sizeof(name), "esp32.irom.cpu%d", i);
      |                                      ^~~~~~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:867,
                 from /qemu/include/qemu/osdep.h:97,
                 from ../hw/xtensa/esp32.c:11:
/usr/include/i386-linux-gnu/bits/stdio2.h:67:10: note: '__builtin___snprintf_chk' output between 16 and 23 bytes into a destination of size 16
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../hw/xtensa/esp32.c:288:53: error: '%d' directive output may be truncated writing between 1 and 8 bytes into a region of size 2 [-Werror=format-truncation=]
  288 |         snprintf(name, sizeof(name), "esp32.drom.cpu%d", i);
      |                                                     ^~
../hw/xtensa/esp32.c:288:38: note: directive argument in the range [0, 27531842]
  288 |         snprintf(name, sizeof(name), "esp32.drom.cpu%d", i);
      |                                      ^~~~~~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:867,
                 from /qemu/include/qemu/osdep.h:97,
                 from ../hw/xtensa/esp32.c:11:
/usr/include/i386-linux-gnu/bits/stdio2.h:67:10: note: '__builtin___snprintf_chk' output between 16 and 23 bytes into a destination of size 16
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```

This patch fixes it for me, feel free to squash