### PR TITLE
fix(psram/eid): use a unique return value for errors (QEMU-241)

### DIFF
--- a/hw/misc/ssi_psram.c
+++ b/hw/misc/ssi_psram.c
@@ -33,7 +33,7 @@ static int get_eid_by_size(uint32_t size_mbytes) {
     default:
         qemu_log_mask(LOG_UNIMP, "%s: PSRAM size %" PRIu32 "MB not implemented\n",
                       __func__, size_mbytes);
-        return 0;
+        return -1;
     }
 }
 
@@ -85,7 +85,7 @@ static void psram_realize(SSIPeripheral *ss, Error **errp)
 {
     SsiPsramState *s = SSI_PSRAM(ss);
     /* Make sure the given size is supported */
-    if (get_eid_by_size(s->size_mbytes) == 0) {
+    if (get_eid_by_size(s->size_mbytes) == -1) {
         error_report("[PSRAM] Invalid size %dMB for the PSRAM", s->size_mbytes);
     }
 


### PR DESCRIPTION
## Description

This makes callers of `get_eid_by_size` able to distinguish the errors from success.

## Related

Fixes #117

## Testing

Ran an image with `qemu-system-xtensa` with `-m 2M` option and noticed that this error was present without patch but not with:
```
qemu-system-xtensa: [PSRAM] Invalid size 2MB for the PSRAM
```

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
