### PR TITLE
hw/xtensa/esp32s3: add sdmmc peripheral (QEMU-276)

### DIFF
--- a/hw/xtensa/esp32s3.c
+++ b/hw/xtensa/esp32s3.c
@@ -31,6 +31,7 @@
 #include "hw/misc/esp32s3_rtc_cntl.h"
 #include "hw/xtensa/esp32s3_intc.h"
 
+#include "hw/sd/dwc_sdmmc.h"
 #include "hw/misc/ssi_psram.h"
 #include "core-esp32s3/core-isa.h"
 #include "qemu/datadir.h"
@@ -151,6 +152,7 @@ typedef struct Esp32s3SocState {
     ESPRgbState rgb;
 
     MemoryRegion iomem;
+    DWCSDMMCState sdmmc;
     DeviceState *eth;
     SsiPsramState *psram;
 
@@ -295,6 +297,22 @@ static void esp32s3_machine_init_psram(Esp32s3SocState *ms, uint32_t size_mbytes
                                 qdev_get_gpio_in_named(psram, SSI_GPIO_CS, 0));
 }
 
+static void esp32s3_machine_init_sd(Esp32s3SocState* ss)
+{
+    DriveInfo *dinfo = drive_get(IF_SD, 0, 0);
+    if (dinfo) {
+        DeviceState *card;
+
+        card = qdev_new(TYPE_SD_CARD);
+        qdev_prop_set_drive_err(card, "drive", blk_by_legacy_dinfo(dinfo),
+                                &error_fatal);
+        /* See the comment on not using sysbus-default in esp32_machine_init_i2c */
+        DeviceState *sdmmc = DEVICE(&ss->sdmmc);
+        SDBus* sd_bus = SD_BUS(qdev_get_child_bus(sdmmc, "sd-bus"));
+        qdev_realize_and_unref(card, BUS(sd_bus), &error_fatal);
+    }
+}
+
 struct Esp32s3MachineState {
     MachineState parent;
 
@@ -407,6 +425,10 @@ static void esp32s3_soc_realize(DeviceState *dev, Error **errp)
                            qdev_get_gpio_in(intmatrix_dev, ETS_UART0_INTR_SOURCE + i));
     }
 
+    qdev_realize(DEVICE(&s->sdmmc), &s->periph_bus, &error_fatal);
+    esp32s3_soc_add_periph_device(sys_mem, &s->sdmmc, DR_REG_SDMMC_BASE);
+    sysbus_connect_irq(SYS_BUS_DEVICE(&s->sdmmc), 0,
+                       qdev_get_gpio_in(intmatrix_dev, ETS_SDIO_HOST_INTR_SOURCE));
 
     /* Emulation of APB_CTRL_DATE_REG, needed for ECO3 revision detection.
      * This is a small hack to avoid creating a whole new device just to emulate one
@@ -527,6 +549,8 @@ static void esp32s3_soc_init(Object *obj)
     qdev_init_gpio_in_named(DEVICE(s), esp32s3_clk_update, ESP32S3_RTC_CLK_UPDATE_GPIO, 1);
 
     object_initialize_child(obj, "twai", &s->twai, TYPE_ESP32S3_TWAI);
+
+    object_initialize_child(obj, "sdmmc", &s->sdmmc, TYPE_DWC_SDMMC);
 }
 
 static Property esp32s3_soc_properties[] = {
@@ -847,6 +871,9 @@ static void esp32s3_machine_init(MachineState *machine)
 
     esp32s3_soc_add_unimp_device(sys_mem, "esp32s3.rmt", DR_REG_RMT_BASE, 0x1000);
     esp32s3_soc_add_unimp_device(sys_mem, "esp32s3.iomux", DR_REG_IO_MUX_BASE, 0x2000);
+
+    
+    esp32s3_machine_init_sd(ss);
 
     /* Need MMU initialized prior to ELF loading,
      * so that ELF gets loaded into virtual addresses


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

Hello, I added the SDMMC peripheral. This is just copy paste from the hw/xtensa/esp32.c.
<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related
Fix for issue : #139.
<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

no extensive test has been done. I only ran the sdmmc_card example program and it worked.

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->
Here is the log output : 

```Adding SPI flash device
ESP-ROM:esp32s3-20210327
Build:Mar 27 2021
rst:0x1 (POWERON),boot:0x4 (SPI_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fce2820,len:0x1568
load:0x403c8700,len:0xf0c
load:0x403cb700,len:0x352c
entry 0x403c8a9c
I (37) boot: ESP-IDF v5.5.1 2nd stage bootloader
I (39) boot: compile time Sep 13 2025 17:54:54
I (39) boot: Multicore bootloader
I (48) boot: chip revision: v0.0
I (49) boot: efuse block revision: v0.0
I (51) boot.esp32s3: Boot SPI Speed : 80MHz
I (52) boot.esp32s3: SPI Mode       : SLOW READ
I (52) boot.esp32s3: SPI Flash Size : 2MB
(-- snip --)
I (215) app_init: Application information:
I (216) app_init: Project name:     sd_card
I (216) app_init: App version:      1
I (216) app_init: Compile time:     Sep 13 2025 17:54:49
I (216) app_init: ELF file SHA256:  491bd1e5e...
I (216) app_init: ESP-IDF:          v5.5.1
I (216) efuse_init: Min chip rev:     v0.0
I (216) efuse_init: Max chip rev:     v0.99 
I (216) efuse_init: Chip rev:         v0.0
(-- snip --)
I (235) main_task: Calling app_main()
I (235) example: Initializing SD card
I (235) example: Using SDMMC peripheral
I (235) example: Mounting filesystem
I (305) example: Filesystem mounted
Name: QEMU!
Type: SDSC
Speed: 160.00 MHz (limit: 20.00 MHz)
Size: 1MB
CSD: ver=1, sector_size=512, capacity=2048 read_bl_len=9
SSR: bus_width=4
I (315) example: Opening file /sdcard/hello.txt
I (345) example: File written
I (345) example: Renaming file /sdcard/hello.txt to /sdcard/foo.txt
I (355) example: Reading file /sdcard/foo.txt
I (355) example: Read from file: 'Hello QEMU!!'
I (355) example: Opening file /sdcard/nihao.txt
I (365) example: File written
I (365) example: Reading file /sdcard/nihao.txt
I (365) example: Read from file: 'Nihao QEMU!!'
I (365) example: Card unmounted
I (365) main_task: Returned from app_main()
```
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

Thanks 
~Romain
