### PR TITLE
rgb_update fix (QEMU-277)

### DIFF
--- a/hw/display/esp_rgb.c
+++ b/hw/display/esp_rgb.c
@@ -213,15 +213,16 @@ static void rgb_update(void* opaque)
         if (width > 0 && height > 0 &&
             (s->from_x + width) <= s->width && (s->from_y + height) <= s->height) {
 
+            uint8_t* source = (uint8_t*)src + (s->from_y * s->width + s->from_x) * bytes_per_pixel;
             uint8_t* dest = data + (s->from_y * s->width + s->from_x) * bytes_per_pixel;
 
             /* Copy the pixels to the framebuffer */
             for (int i = 0; i < height; i++) {
-                dma_memory_read(src_as, src, dest, width * bytes_per_pixel, MEMTXATTRS_UNSPECIFIED);
+                dma_memory_read(src_as, (uint32_t)source, dest, width * bytes_per_pixel, MEMTXATTRS_UNSPECIFIED);
                 /* Go to the next line in the destination */
                 dest += s->width * bytes_per_pixel;
                 /* Same goes for the source */
-                src += width * bytes_per_pixel;
+                source += width * bytes_per_pixel;
             }
 
             dpy_gfx_update(s->con, s->from_x, s->from_y, width, height);


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

I noticed that if I'm not updating the whole screen of the QEMU RGB device that the output was incorrect. This is now corrected so that you can now update parts of the screen again.

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
