### PR TITLE
Fix gdma not checking ownership and clearing the owner bit correctly. (QEMU-280)

### DIFF
--- a/hw/dma/esp_gdma.c
+++ b/hw/dma/esp_gdma.c
@@ -307,10 +307,10 @@ bool esp_gdma_read_channel(ESPGdmaState *s, uint32_t chan, uint8_t* buffer, uint
     uint32_t out_addr = ((ESP_GDMA_RAM_ADDR >> 20) << 20) | FIELD_EX32(state->link, GDMA_OUT_LINK, ADDR);
 
     /* Boolean to mark whether we need to check the owner for in and out buffers */
-    const bool owner_check_out = FIELD_EX32(state[ESP_GDMA_OUT_IDX].conf1, GDMA_OUT_CONF1, CHECK_OWNER);
+    const bool owner_check_out = FIELD_EX32(state->conf1, GDMA_OUT_CONF1, CHECK_OWNER);
 
     /* Boolean to mark whether the transmit (out) buffers must have their owner bit cleared here */
-    const bool clear_out = FIELD_EX32(state[ESP_GDMA_OUT_IDX].conf0, GDMA_OUT_CONF0, AUTO_WRBACK);
+    const bool clear_out = FIELD_EX32(state->conf0, GDMA_OUT_CONF0, AUTO_WRBACK);
 
     /* Pointer to the lists that will be browsed by the loop below */
     GdmaLinkedList out_list;
@@ -360,7 +360,7 @@ bool esp_gdma_read_channel(ESPGdmaState *s, uint32_t chan, uint8_t* buffer, uint
                 out_list.config.owner = 0;
 
                 /* Write back the modified descriptor, should always be valid */
-                valid = esp_gdma_read_descr(s, out_addr, &out_list);
+                valid = esp_gdma_write_descr(s, out_addr, &out_list);
                 assert(valid);
             }
 


### PR DESCRIPTION
This didn't matter in the past but recent version of the idf check that the bit has been cleared in gdma_link_mount_buffers()

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
