### PR TITLE
hw/ssi/esp32_spi: fix RX bounds check and add dummy cycle handling (QEMU-282)

### DIFF
--- a/hw/ssi/esp32_spi.c
+++ b/hw/ssi/esp32_spi.c
@@ -175,14 +175,19 @@ static void esp32_spi_cs_set(Esp32SpiState *s, int value)
     }
 }
 
+static void esp32_spi_dummy_cycles(Esp32SpiState *s, int dummy_bytes)
+{
+    for (int i = 0; i < dummy_bytes; i++) {
+        ssi_transfer(s->spi, 0);
+    }
+}
+
 static void esp32_spi_transaction(Esp32SpiState *s, Esp32SpiTransaction *t)
 {
     esp32_spi_cs_set(s, 0);
     esp32_spi_txrx_buffer(s, &t->cmd, t->cmd_bytes, 0);
     esp32_spi_txrx_buffer(s, &t->addr, t->addr_bytes, 0);
-    for (int d = 0; d < t->dummy_bytes; d++) {
-        ssi_transfer(s->spi, 0);
-    }
+    esp32_spi_dummy_cycles(s, t->dummy_bytes);
     esp32_spi_txrx_buffer(s, t->data, t->data_tx_bytes, t->data_rx_bytes);
     esp32_spi_cs_set(s, 1);
 }

--- a/hw/ssi/esp32_spi.c
+++ b/hw/ssi/esp32_spi.c
@@ -146,6 +146,7 @@ typedef struct Esp32SpiTransaction {
     uint32_t cmd;
     int addr_bytes;
     uint32_t addr;
+    int dummy_bytes;
     int data_tx_bytes;
     int data_rx_bytes;
     uint32_t* data;
@@ -157,11 +158,11 @@ static void esp32_spi_txrx_buffer(Esp32SpiState *s, void *buf, int tx_bytes, int
     uint8_t *c_buf = (uint8_t*) buf;
     for (int i = 0; i < bytes; ++i) {
         uint8_t byte = 0;
-        if (byte < tx_bytes) {
+        if (i < tx_bytes) {
             memcpy(&byte, c_buf + i, 1);
         }
         uint32_t res = ssi_transfer(s->spi, byte);
-        if (byte < rx_bytes) {
+        if (i < rx_bytes) {
             memcpy(c_buf + i, &res, 1);
         }
     }
@@ -179,6 +180,9 @@ static void esp32_spi_transaction(Esp32SpiState *s, Esp32SpiTransaction *t)
     esp32_spi_cs_set(s, 0);
     esp32_spi_txrx_buffer(s, &t->cmd, t->cmd_bytes, 0);
     esp32_spi_txrx_buffer(s, &t->addr, t->addr_bytes, 0);
+    for (int d = 0; d < t->dummy_bytes; d++) {
+        ssi_transfer(s->spi, 0);
+    }
     esp32_spi_txrx_buffer(s, t->data, t->data_tx_bytes, t->data_rx_bytes);
     esp32_spi_cs_set(s, 1);
 }
@@ -284,6 +288,23 @@ static void esp32_spi_do_command(Esp32SpiState* s, uint32_t cmd_reg)
         if (FIELD_EX32(s->user_reg, SPI_USER, ADDR)) {
             t.addr_bytes = bitlen_to_bytes(FIELD_EX32(s->user1_reg, SPI_USER1, ADDR_BITLEN));
             t.addr = bswap32(s->addr_reg);
+        }
+        /* Inject 1 dummy byte for SPI flash fast-read commands when DUMMY
+         * phase is enabled.  The m25p80 flash model expects this byte
+         * between address and data for DOR/QOR/FastRead etc.
+         * PSRAM commands handle dummy internally - don't inject for them. */
+        if (FIELD_EX32(s->user_reg, SPI_USER, DUMMY)) {
+            switch (FIELD_EX32(s->user2_reg, SPI_USER2, COMMAND_VALUE)) {
+            case 0x0b: case 0x0c:  /* Fast Read / Fast Read 4B */
+            case 0x3b: case 0x3c:  /* DOR / DOR 4B */
+            case 0x6b: case 0x6c:  /* QOR / QOR 4B */
+            case 0xbb: case 0xbc:  /* DIOR / DIOR 4B */
+            case 0xeb: case 0xec:  /* QIOR / QIOR 4B */
+                t.dummy_bytes = 1;
+                break;
+            default:
+                break;
+            }
         }
         if (FIELD_EX32(s->user_reg, SPI_USER, MOSI)) {
             t.data = &s->data_reg[0];

--- a/hw/ssi/esp32c3_spi.c
+++ b/hw/ssi/esp32c3_spi.c
@@ -127,11 +127,11 @@ static void esp32c3_spi_txrx_buffer(ESP32C3SpiState *s,
     int bytes = MAX(tx_bytes, rx_bytes);
     for (int i = 0; i < bytes; ++i) {
         uint8_t byte = 0;
-        if (byte < tx_bytes) {
+        if (i < tx_bytes) {
             memcpy(&byte, tx + i, 1);
         }
         uint32_t res = ssi_transfer(s->spi, byte);
-        if (byte < rx_bytes) {
+        if (i < rx_bytes) {
             memcpy(rx + i, &res, 1);
         }
     }

--- a/hw/ssi/esp32s3_spi.c
+++ b/hw/ssi/esp32s3_spi.c
@@ -142,11 +142,11 @@ static void esp32s3_spi_txrx_buffer(ESP32S3SpiState *s,
     int bytes = MAX(tx_bytes, rx_bytes);
     for (int i = 0; i < bytes; ++i) {
         uint8_t byte = 0;
-        if (byte < tx_bytes) {
+        if (i < tx_bytes) {
             memcpy(&byte, tx + i, 1);
         }
         uint32_t res = ssi_transfer(s->spi, byte);
-        if (byte < rx_bytes) {
+        if (i < rx_bytes) {
             memcpy(rx + i, &res, 1);
         }
     }


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->
__hw/ssi/esp32_spi, esp32c3_spi, esp32s3_spi: fix txrx buffer bounds check and add flash read dummy cycles__

__Problem 1 — Incorrect bounds check in `txrx_buffer` (all three variants)__

All three ESP32 SPI controller models (`esp32_spi.c`, `esp32c3_spi.c`, `esp32s3_spi.c`) contain the same bug in their `txrx_buffer` function:

```c
// Before (buggy):
if (byte < tx_bytes) { ... }  // 'byte' is the data value, not the loop index
if (byte < rx_bytes) { ... }
```

The local variable `byte` holds the data being transferred, not the loop position. Using it as a bounds guard makes TX/RX behaviour depend on data values rather than byte positions. In the worst case, a received byte with a value ≥ `rx_bytes` is silently dropped. This is a latent correctness bug in all three variants.

__Fix:__ Replace `byte` with the loop index `i` in both conditions.

---

__Problem 2 — Missing dummy cycles for flash fast-read commands (`esp32_spi.c` only)__

SPI flash fast-read commands (DOR `0x3B`, Fast Read `0x0B`, QOR `0x6B`, DIOR `0xBB`, QIOR `0xEB` and their 4-byte address variants) require one dummy byte to be clocked between the address phase and the data phase. The flash chip uses those extra clock cycles to prepare its output buffer. Without them, the m25p80 flash model consumes the first real data byte as the dummy, shifting all read data by one byte.

The `esp32c3_spi.c` and `esp32s3_spi.c` variants already handle dummy cycles correctly via `esp32c3_spi_dummy_cycles()` / `esp32s3_spi_dummy_cycles()`. The original `esp32_spi.c` had no dummy phase at all.

This caused NVS operations under ESP-IDF v5.5.3 to fail: every page read returned corrupted data, resulting in `ESP_ERR_NVS_NOT_FOUND` for all stored keys.

__Fix:__ Add `esp32_spi_dummy_cycles()` helper (matching the pattern in the C3/S3 variants) and call it from `esp32_spi_transaction()`. In the USR command path, set `dummy_bytes = 1` when `SPI_USER.DUMMY` is enabled and the opcode is a known flash fast-read command. PSRAM commands (which also use `SPI_USER.DUMMY`) are excluded as they handle dummy cycles internally in their peripheral models.

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
