### PR TITLE
esp32s3: expose canbus machine property and wire TWAI peripheral

### DIFF
--- a/hw/xtensa/esp32s3.c
+++ b/hw/xtensa/esp32s3.c
@@ -64,6 +64,7 @@
 #include "hw/misc/esp32s3_xts_aes.h"
 #include "hw/misc/esp32s3_pms.h"
 #include "hw/net/can/esp32s3_twai.h"
+#include "net/can_emu.h"
 
 #include "cpu_esp32s3.h"
 
@@ -318,6 +319,7 @@ struct Esp32s3MachineState {
 
     Esp32s3SocState esp32s3;
     DeviceState *flash_dev;
+    CanBusState *canbus;
 };
 #define TYPE_ESP32S3_MACHINE MACHINE_TYPE_NAME("esp32s3")
 
@@ -632,6 +634,11 @@ static void esp32s3_machine_init(MachineState *machine)
     // qdev_prop_set_chr(DEVICE(ss), "serial0", serial_hd(0));
     // qdev_prop_set_chr(DEVICE(ss), "serial1", serial_hd(1));
     // qdev_prop_set_chr(DEVICE(ss), "serial2", serial_hd(2));
+
+    if (ms->canbus) {
+        object_property_set_link(OBJECT(&ss->twai), "canbus",
+                                 OBJECT(ms->canbus), &error_abort);
+    }
 
     qdev_realize(DEVICE(ss), NULL, &error_fatal);
 
@@ -984,6 +991,11 @@ static void esp32s3_machine_class_init(ObjectClass *oc, void *data)
     mc->default_cpus = 2;
     mc->default_ram_size = 0;
     mc->fixup_ram_size = esp32s3_fixup_ram_size;
+
+    object_class_property_add_link(oc, "canbus", TYPE_CAN_BUS,
+                                   offsetof(Esp32s3MachineState, canbus),
+                                   object_property_allow_set_link,
+                                   OBJ_PROP_LINK_STRONG);
 }
 
 static const TypeInfo esp32s3_info = {


### PR DESCRIPTION
The ESP32-S3 TWAI device (esp32s3_twai.c, inheriting esp32_twai.c) already implements a 'canbus' link property and calls can_sja_connect_to_bus() in its realize handler — but the machine (esp32s3.c) never exposed a corresponding property or set the link, leaving the TWAI peripheral permanently CAN-isolated.

This patch wires the two together:
- Add CanBusState *canbus field to Esp32s3MachineState
- Expose it as a machine property via object_class_property_add_link
- Set the TWAI 'canbus' link in machine_init before qdev_realize

Usage:
  -object can-bus,id=canbus0 -object can-host-socketcan,id=can-host0,if=vcan0,canbus=canbus0 -machine esp32s3,canbus=canbus0

Tested with ESP32-S3 firmware on vcan0 (Linux virtual SocketCAN). Firmware CAN TX and RX confirmed working via candump.

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
