### PR TITLE
riscv/esp32c3: fix missed systimer interrupt for past deadlines

### DIFF
--- a/hw/riscv/esp32c3_intmatrix.c
+++ b/hw/riscv/esp32c3_intmatrix.c
@@ -103,14 +103,22 @@ static void esp32c3_intmatrix_irq_handler(void *opaque, int n, int level)
     }
 
     /* If the new level is high, check that the priority is equal or bigger than the threshold.
-     * If that's the case, we can execute the interrupt, else, mark it as pending. */
+     * If that's the case, issue a pulse to the CPU line.
+     *
+     * NOTE: we also pulse when the CPU currently cannot accept interrupts (e.g. MSTATUS.MIE=0).
+     * The ESP CPU model will latch this pulse as pending and deliver it once interrupts are
+     * re-enabled. Without this, an interrupt asserted while MIE=0 can stay stuck in the matrix
+     * pending bitmap forever because there is no later edge to retrigger delivery. */
     if (level == 1) {
 #if INTMATRIX_DEBUG
         info_report("\x1b[31m[INTMATRIX] IRQ %d priority set to %d, CPU threshold %d \x1b[0m\n",
                     line, s->irq_prio[line], s->irq_thres);
 #endif
 
-        if (s->irq_prio[line] >= s->irq_thres && esp32c3_intmatrix_can_trigger(s)) {
+        if (s->irq_prio[line] >= s->irq_thres) {
+            if (!esp32c3_intmatrix_can_trigger(s)) {
+                SET_BIT(s->irq_pending, line);
+            }
             esp32c3_do_int(s, line);
         } else {
             SET_BIT(s->irq_pending, line);

--- a/hw/timer/esp32c3_systimer.c
+++ b/hw/timer/esp32c3_systimer.c
@@ -13,65 +13,46 @@
 #include "hw/boards.h"
 #include "hw/timer/esp32c3_systimer.h"
 
-
 static uint64_t esp32c3_systimer_read(void *opaque, hwaddr addr, unsigned int size)
 {
     ESP32C3SysTimerClass *class = ESP32C3_SYSTIMER_GET_CLASS(opaque);
     uint64_t r = 0;
 
-    switch (addr) {
-        case A_SYSTIMER_CONF:
-            /* On the C3, bit 27 is always 0, bit 25 is always high */
-            r = class->parent_systimer_read(opaque, addr, size);
-            r &= ~BIT(27);
-            r |=  BIT(25);
-            break;
+    switch (addr)
+    {
+    case A_SYSTIMER_CONF:
+        /* On the C3, bit 27 is always 0, bit 25 is always high */
+        r = class->parent_systimer_read(opaque, addr, size);
+        r &= ~BIT(27);
+        r |= BIT(25);
+        break;
 
-        case A_SYSTIMER_REAL_TARGET0_LO:
-        case A_SYSTIMER_REAL_TARGET0_HI:
-        case A_SYSTIMER_REAL_TARGET1_LO:
-        case A_SYSTIMER_REAL_TARGET1_HI:
-        case A_SYSTIMER_REAL_TARGET2_LO:
-        case A_SYSTIMER_REAL_TARGET2_HI:
-            /* These registers are not supported on the C3 hardware, do nothing! */
-            break;
+    case A_SYSTIMER_REAL_TARGET0_LO:
+    case A_SYSTIMER_REAL_TARGET0_HI:
+    case A_SYSTIMER_REAL_TARGET1_LO:
+    case A_SYSTIMER_REAL_TARGET1_HI:
+    case A_SYSTIMER_REAL_TARGET2_LO:
+    case A_SYSTIMER_REAL_TARGET2_HI:
+        /* These registers are not supported on the C3 hardware, do nothing! */
+        break;
 
-        default:
-            r = class->parent_systimer_read(opaque, addr, size);
-            break;
+    default:
+        r = class->parent_systimer_read(opaque, addr, size);
+        break;
     }
 
     return r;
 }
 
-static void esp32c3_systimer_write(void *opaque, hwaddr addr, uint64_t value, unsigned int size)
-{
-    ESP32C3SysTimerClass *class = ESP32C3_SYSTIMER_GET_CLASS(opaque);
-    ESP32C3SysTimerState *s = ESP32C3_SYSTIMER(opaque);
-
-    class->parent_systimer_write(opaque, addr, value, size);
-
-    if (addr == A_SYSTIMER_INT_ENA) {
-        /* If interrupt enable is set after comparator programming, force a
-         * re-evaluation so "alarm already passed" cases are not missed.
-         */
-        class->parent_class.comparators_reprogram(&s->parent);
-    }
-}
-
-
 static void esp32c3_systimer_class_init(ObjectClass *klass, void *data)
 {
-    ESP32C3SysTimerClass* esp32c3 = ESP32C3_SYSTIMER_CLASS(klass);
-    ESPSysTimerClass* esp = ESP_SYSTIMER_CLASS(klass);
+    ESP32C3SysTimerClass *esp32c3 = ESP32C3_SYSTIMER_CLASS(klass);
+    ESPSysTimerClass *esp = ESP_SYSTIMER_CLASS(klass);
 
-    /* Override register read/write methods */
+    /* Override the register read method */
     esp32c3->parent_systimer_read = esp->systimer_ops.read;
-    esp32c3->parent_systimer_write = esp->systimer_ops.write;
     esp->systimer_ops.read = esp32c3_systimer_read;
-    esp->systimer_ops.write = esp32c3_systimer_write;
 }
-
 
 static const TypeInfo esp32c3_systimer_info = {
     .name = TYPE_ESP32C3_SYSTIMER,
@@ -81,11 +62,9 @@ static const TypeInfo esp32c3_systimer_info = {
     .class_size = sizeof(ESP32C3SysTimerClass),
 };
 
-
 static void esp32c3_systimer_register_types(void)
 {
     type_register_static(&esp32c3_systimer_info);
 }
-
 
 type_init(esp32c3_systimer_register_types)

--- a/hw/timer/esp32c3_systimer.c
+++ b/hw/timer/esp32c3_systimer.c
@@ -13,41 +13,42 @@
 #include "hw/boards.h"
 #include "hw/timer/esp32c3_systimer.h"
 
+
 static uint64_t esp32c3_systimer_read(void *opaque, hwaddr addr, unsigned int size)
 {
     ESP32C3SysTimerClass *class = ESP32C3_SYSTIMER_GET_CLASS(opaque);
     uint64_t r = 0;
 
-    switch (addr)
-    {
-    case A_SYSTIMER_CONF:
-        /* On the C3, bit 27 is always 0, bit 25 is always high */
-        r = class->parent_systimer_read(opaque, addr, size);
-        r &= ~BIT(27);
-        r |= BIT(25);
-        break;
+    switch (addr) {
+        case A_SYSTIMER_CONF:
+            /* On the C3, bit 27 is always 0, bit 25 is always high */
+            r = class->parent_systimer_read(opaque, addr, size);
+            r &= ~BIT(27);
+            r |= BIT(25);
+            break;
 
-    case A_SYSTIMER_REAL_TARGET0_LO:
-    case A_SYSTIMER_REAL_TARGET0_HI:
-    case A_SYSTIMER_REAL_TARGET1_LO:
-    case A_SYSTIMER_REAL_TARGET1_HI:
-    case A_SYSTIMER_REAL_TARGET2_LO:
-    case A_SYSTIMER_REAL_TARGET2_HI:
+        case A_SYSTIMER_REAL_TARGET0_LO:
+        case A_SYSTIMER_REAL_TARGET0_HI:
+        case A_SYSTIMER_REAL_TARGET1_LO:
+        case A_SYSTIMER_REAL_TARGET1_HI:
+        case A_SYSTIMER_REAL_TARGET2_LO:
+        case A_SYSTIMER_REAL_TARGET2_HI:
         /* These registers are not supported on the C3 hardware, do nothing! */
         break;
 
-    default:
-        r = class->parent_systimer_read(opaque, addr, size);
-        break;
+        default:
+            r = class->parent_systimer_read(opaque, addr, size);
+            break;
     }
 
     return r;
 }
 
+
 static void esp32c3_systimer_class_init(ObjectClass *klass, void *data)
 {
-    ESP32C3SysTimerClass *esp32c3 = ESP32C3_SYSTIMER_CLASS(klass);
-    ESPSysTimerClass *esp = ESP_SYSTIMER_CLASS(klass);
+    ESP32C3SysTimerClass* esp32c3 = ESP32C3_SYSTIMER_CLASS(klass);
+    ESPSysTimerClass* esp = ESP_SYSTIMER_CLASS(klass);
 
     /* Override the register read method */
     esp32c3->parent_systimer_read = esp->systimer_ops.read;

--- a/hw/timer/esp32c3_systimer.c
+++ b/hw/timer/esp32c3_systimer.c
@@ -44,15 +44,32 @@ static uint64_t esp32c3_systimer_read(void *opaque, hwaddr addr, unsigned int si
     return r;
 }
 
+static void esp32c3_systimer_write(void *opaque, hwaddr addr, uint64_t value, unsigned int size)
+{
+    ESP32C3SysTimerClass *class = ESP32C3_SYSTIMER_GET_CLASS(opaque);
+    ESP32C3SysTimerState *s = ESP32C3_SYSTIMER(opaque);
+
+    class->parent_systimer_write(opaque, addr, value, size);
+
+    if (addr == A_SYSTIMER_INT_ENA) {
+        /* If interrupt enable is set after comparator programming, force a
+         * re-evaluation so "alarm already passed" cases are not missed.
+         */
+        class->parent_class.comparators_reprogram(&s->parent);
+    }
+}
+
 
 static void esp32c3_systimer_class_init(ObjectClass *klass, void *data)
 {
     ESP32C3SysTimerClass* esp32c3 = ESP32C3_SYSTIMER_CLASS(klass);
     ESPSysTimerClass* esp = ESP_SYSTIMER_CLASS(klass);
 
-    /* Override the register read method */
+    /* Override register read/write methods */
     esp32c3->parent_systimer_read = esp->systimer_ops.read;
+    esp32c3->parent_systimer_write = esp->systimer_ops.write;
     esp->systimer_ops.read = esp32c3_systimer_read;
+    esp->systimer_ops.write = esp32c3_systimer_write;
 }
 
 

--- a/hw/timer/esp32c3_systimer.c
+++ b/hw/timer/esp32c3_systimer.c
@@ -24,7 +24,7 @@ static uint64_t esp32c3_systimer_read(void *opaque, hwaddr addr, unsigned int si
             /* On the C3, bit 27 is always 0, bit 25 is always high */
             r = class->parent_systimer_read(opaque, addr, size);
             r &= ~BIT(27);
-            r |= BIT(25);
+            r |=  BIT(25);
             break;
 
         case A_SYSTIMER_REAL_TARGET0_LO:
@@ -33,8 +33,8 @@ static uint64_t esp32c3_systimer_read(void *opaque, hwaddr addr, unsigned int si
         case A_SYSTIMER_REAL_TARGET1_HI:
         case A_SYSTIMER_REAL_TARGET2_LO:
         case A_SYSTIMER_REAL_TARGET2_HI:
-        /* These registers are not supported on the C3 hardware, do nothing! */
-        break;
+            /* These registers are not supported on the C3 hardware, do nothing! */
+            break;
 
         default:
             r = class->parent_systimer_read(opaque, addr, size);
@@ -55,6 +55,7 @@ static void esp32c3_systimer_class_init(ObjectClass *klass, void *data)
     esp->systimer_ops.read = esp32c3_systimer_read;
 }
 
+
 static const TypeInfo esp32c3_systimer_info = {
     .name = TYPE_ESP32C3_SYSTIMER,
     .parent = TYPE_ESP_SYSTIMER,
@@ -63,9 +64,11 @@ static const TypeInfo esp32c3_systimer_info = {
     .class_size = sizeof(ESP32C3SysTimerClass),
 };
 
+
 static void esp32c3_systimer_register_types(void)
 {
     type_register_static(&esp32c3_systimer_info);
 }
+
 
 type_init(esp32c3_systimer_register_types)

--- a/include/hw/timer/esp32c3_systimer.h
+++ b/include/hw/timer/esp32c3_systimer.h
@@ -29,5 +29,4 @@ typedef struct ESP32C3SysTimerClass {
 
     /* Virtual attributes/methods overriden */
     uint64_t (*parent_systimer_read)(void *opaque, hwaddr addr, unsigned int size);
-    void (*parent_systimer_write)(void *opaque, hwaddr addr, uint64_t value, unsigned int size);
 } ESP32C3SysTimerClass;

--- a/include/hw/timer/esp32c3_systimer.h
+++ b/include/hw/timer/esp32c3_systimer.h
@@ -29,4 +29,5 @@ typedef struct ESP32C3SysTimerClass {
 
     /* Virtual attributes/methods overriden */
     uint64_t (*parent_systimer_read)(void *opaque, hwaddr addr, unsigned int size);
+    void (*parent_systimer_write)(void *opaque, hwaddr addr, uint64_t value, unsigned int size);
 } ESP32C3SysTimerClass;

--- a/include/hw/timer/esp32c3_systimer.h
+++ b/include/hw/timer/esp32c3_systimer.h
@@ -26,7 +26,6 @@ typedef struct ESP32C3SysTimerState {
 
 typedef struct ESP32C3SysTimerClass {
     ESPSysTimerClass parent_class;
-
     /* Virtual attributes/methods overriden */
     uint64_t (*parent_systimer_read)(void *opaque, hwaddr addr, unsigned int size);
     void (*parent_systimer_write)(void *opaque, hwaddr addr, uint64_t value, unsigned int size);

--- a/include/hw/timer/esp32c3_systimer.h
+++ b/include/hw/timer/esp32c3_systimer.h
@@ -26,6 +26,7 @@ typedef struct ESP32C3SysTimerState {
 
 typedef struct ESP32C3SysTimerClass {
     ESPSysTimerClass parent_class;
+
     /* Virtual attributes/methods overriden */
     uint64_t (*parent_systimer_read)(void *opaque, hwaddr addr, unsigned int size);
     void (*parent_systimer_write)(void *opaque, hwaddr addr, uint64_t value, unsigned int size);

--- a/target/riscv/esp_cpu.c
+++ b/target/riscv/esp_cpu.c
@@ -157,12 +157,17 @@ static void esp_cpu_irq_handler(void *opaque, int n, int level)
 {
     EspRISCVCPU *cpu = (EspRISCVCPU*) opaque;
 
-    /* Interrupt incoming if level is not 0, make sure we can receive interrupts */
-    if (level && esp_cpu_accept_interrupts(cpu)) {
-        cpu->irq_pending = true;
-        cpu->irq_cause = n;
-        qemu_irq_raise(cpu->parent_irq);
+    /* Record incoming interrupt regardless of current MSTATUS.MIE state.
+     * The parent RISC-V core will gate delivery based on CSR state; if we
+     * drop here, edge-like pulses can be lost while interrupts are masked.
+     */
+    if (!level || cpu->irq_pending) {
+        return;
     }
+
+    cpu->irq_pending = true;
+    cpu->irq_cause = n;
+    qemu_irq_raise(cpu->parent_irq);
 }
 
 


### PR DESCRIPTION
## Background
This PR fixes an intermittent interrupt delivery issue on ESP32-C3 emulation where a SYSTIMER target interrupt can be missed when the programmed deadline is already in the past (or effectively reaches the comparator during a masked-interrupt window).

The user-visible symptom is a sporadic failure in timer edge-case tests (for example, immediate/deadline-zero style paths), where firmware observes SYSTIMER status bits but never receives the expected trap on the mapped CPU interrupt line.

## Reproduction
Environment used during verification:
- QEMU machine: `-M esp32c3`
- Binary: BlueOS unit-test image (`unittest_runner-esp32.img`)

Observed failure pattern before this fix:
- Timer path prints a past-deadline warning (target already reached), but callback/trap may be missed.
- `test_timer_edge_cases` could fail intermittently.

## Root Cause Analysis
The issue is caused by a delivery gap across SYSTIMER -> interrupt matrix -> CPU latch when interrupts are temporarily masked.

1. SYSTIMER comparator can assert while local interrupt acceptance is masked (`MSTATUS.MIE=0`) or while CPU is not currently accepting a new IRQ.
2. Old interrupt matrix behavior only pulsed the CPU line when `esp_cpu_accept_interrupts()` returned true.
3. In masked windows, matrix state could become pending without delivering a pulse that the CPU model would latch.
4. If no new edge occurred afterward, the event stayed effectively stranded and no trap was taken.

There is also a sequencing hazard when firmware enables comparator/loads target first and sets `INT_ENA` later; this can miss immediate reevaluation for already-passed alarms.

## What This PR Changes
### 1) CPU-side IRQ latching improvement
File: `target/riscv/esp_cpu.c`
- `esp_cpu_irq_handler()` now latches incoming interrupt requests regardless of current `MSTATUS.MIE` state.
- Delivery gating remains the responsibility of the parent RISC-V interrupt execution path.
- Prevents edge-like pulses from being dropped while interrupts are masked.

### 2) ESP32-C3 interrupt matrix delivery fix
File: `hw/riscv/esp32c3_intmatrix.c`
- For qualified high-level sources (`priority >= threshold`), the matrix now pulses the CPU output line even when interrupts are currently masked.
- Pending bookkeeping is preserved so level behavior remains coherent.
- Prevents "pending but never retriggered" scenarios.

### 3) ESP32-C3 systimer re-evaluation on INT_ENA writes
Files:
- `hw/timer/esp32c3_systimer.c`
- `include/hw/timer/esp32c3_systimer.h`

Changes:
- Add C3 write override hook to call parent write handler.
- When `A_SYSTIMER_INT_ENA` is written, force comparator reprogram/evaluation.
- Covers ordering where interrupt enable is set after comparator value/load, including already-passed target cases.

## Why This Is Safe
- The fix does not change IRQ priority/threshold policy; it only ensures eligible events are actually delivered/latchable across masked windows.
- CPU still respects architectural interrupt gating; this PR avoids dropping the request before that gating stage.
- SYSTIMER behavior remains consistent with existing compare/reload logic; only missed reevaluation timing is addressed.

## Validation
### Build
- `ninja -C build qemu-system-riscv32`

### Runtime
Using the command above, observed:
- `test_timer_edge_cases` passes on the past-deadline path (`Set systimer interrupt at 2`).
- trap observed on mapped interrupt cause (`mcause=0x80000001`) and handler prints SYSTIMER interrupt.
- broader unit-test run continues past prior failure point.

## Scope
This PR focuses on ESP32-C3 interrupt delivery for SYSTIMER edge cases and does not modify unrelated machine behavior.



## Signature
Prepared with assistance from Codex (OpenAI GPT-5).
