### PR TITLE
hw/misc/ssi_psram: bounds-check the address before dereferencing data_mr

### DIFF
--- a/hw/misc/ssi_psram.c
+++ b/hw/misc/ssi_psram.c
@@ -135,7 +135,7 @@ static void psram_write_data(SsiPsramState *s, off_t offset, uint8_t byte)
     uint8_t* ptr = (uint8_t*) memory_region_get_ram_ptr(&s->data_mr);
     const uint32_t size_bytes = s->size_mbytes * 1024 * 1024;
     off_t destination = s->addr + offset;
-    if (destination < size_bytes) {
+    if (destination >= 0 && destination < size_bytes) {
         ptr[destination] = byte;
     }
 }
@@ -150,7 +150,7 @@ static uint8_t psram_read_data(SsiPsramState *s, off_t offset)
     uint8_t* ptr = (uint8_t*) memory_region_get_ram_ptr(&s->data_mr);
     const uint32_t size_bytes = s->size_mbytes * 1024 * 1024;
     off_t destination = s->addr + offset;
-    if (destination < size_bytes) {
+    if (destination >= 0 && destination < size_bytes) {
         return ptr[destination];
     }
     return 0;


### PR DESCRIPTION
## Summary

`SsiPsramState.addr` is declared as `int` (signed 32-bit). When the SPI controller sends a 32-bit PSRAM address with bit 31 set (any address ≥ `0x80000000`, common on ESP32-S3 PSRAM mappings), the address accumulator in `psram_octal_write` / `psram_quad_write_idle` overflows into the sign bit and produces a negative value.

The bounds check in `psram_read_data` and `psram_write_data` then misbehaves:

```c
off_t destination = s->addr + offset;     // signed, negative
if (destination < size_bytes) {           // signed compare → TRUE
    return ptr[destination];               // SIGSEGV
}
```

`destination` is `off_t` (signed `long`, 64-bit on x86_64) and `size_bytes` is `uint32_t`. Under the usual arithmetic conversions `size_bytes` is widened to signed `long`; the comparison is signed; a negative `destination` passes "less than" any positive `size_bytes`, and the code dereferences `ptr` with a huge negative index. SIGSEGV in the TCG MMU helper thread.

## Fix

Add a `destination >= 0` guard to both `psram_read_data` and `psram_write_data` so out-of-range addresses (negative under signed overflow, or genuinely too large) return 0 / are silently dropped instead of crashing the guest QEMU process.

## Reproducer

No firmware needed — the ESP32-S3 mask ROM emits a SPI transaction during early boot that triggers the path:

```bash
truncate -s 16777216 /tmp/blank16mb.bin

qemu-system-xtensa -M esp32s3 -nographic -monitor none -no-reboot \
    -device ssi_psram,bus=spi,cs=1,is_octal=true,size_mbytes=8 \
    -drive file=/tmp/blank16mb.bin,if=mtd,format=raw
```

Without the fix: SIGSEGV inside ~100 ms. With the fix: QEMU runs the mask ROM cleanly.

## gdb backtrace (debug build)

```
Thread 3 "qemu-system-xte" received signal SIGSEGV, Segmentation fault.
0x00005555559d367e in psram_read_data (s=0x5555591695c0, offset=0)
    at hw/misc/ssi_psram.c:154
154	        return ptr[destination];

#0  psram_read_data (s=0x5555591695c0, offset=0)            at hw/misc/ssi_psram.c:154
#1  psram_octal_read (s=0x5555591695c0)                     at hw/misc/ssi_psram.c:302
#2  psram_transfer (dev=0x5555591695c0, value=0)            at hw/misc/ssi_psram.c:437
#3  ssi_transfer_raw_default (dev=0x5555591695c0, val=0)    at hw/ssi/ssi.c:92
#4  ssi_transfer (bus=0x555556ab4480, val=0)                at hw/ssi/ssi.c:165
#5  esp32s3_spi_txrx_buffer (..., tx_bytes=0, rx_bytes=3)   at hw/ssi/esp32s3_spi.c:148
#6  esp32s3_spi_perform_transaction (...)                   at hw/ssi/esp32s3_spi.c:196
#7  esp32s3_spi_special_command (..., command=1048576)      at hw/ssi/esp32s3_spi.c:368
#8  esp32s3_spi_write (...)                                 at hw/ssi/esp32s3_spi.c:387
[... TCG dispatch ...]
```

State at the crash:

```
s->is_octal       = true
s->size_mbytes    = 8
s->addr           = -1426063360       (= 0xab000000 reinterpreted as int)
s->state          = ST_PROCESSING
ptr (data_mr ram) = 0x7fff65200000    (valid 8 MB region)
destination       = -1426063360
size_bytes        = 8388608           (8 MB)
```

`ptr[destination]` is then `ptr - 1426063360` → SIGSEGV.

## Why this hasn't been seen before

Most ESP-IDF firmware that exercises octal PSRAM does so via the IDF v5.5+ octal driver under conditions where the legitimately-negative address pattern doesn't arise. The crash is exposed when the SPI controller routes a mask-ROM-era SPI transaction to a manually-attached PSRAM device at CS=1 on the same bus as the SPI flash, which is what happens when a downstream tool (e.g., the cartridge-pcb framework) attaches an octal PSRAM device to support firmware that requires `CONFIG_SPIRAM_MODE_OCT=y`.

## Affected projects

This blocks full-system QEMU boot of any ESP-IDF firmware built for ESP32-S3 WROOM-1 N16R8 modules (16 MB flash + 8 MB octal PSRAM), including the bitaxeorg/ESP-Miner factory image used by Bitaxe Ultra.

## Test environment

- QEMU: `v9.2.0-178-g33cc9a8740` (esp-develop tip, 2026-02-03)
- Build: `--target-list=xtensa-softmmu,riscv32-softmmu --enable-debug`
- Host: Linux 6.14, gcc 13, glibc 2.39
- Reproduces identically on the released tag `esp-develop-9.2.2-20250817`

## A note on the more thorough fix

A more thorough fix would change `int addr` to `uint32_t addr` in `include/hw/misc/ssi_psram.h` and remove the `s->addr = -1` sentinel on line 461 (set but never read elsewhere). The minimal patch in this PR is the smallest change that stops the crash without touching state-machine semantics — preferred for backporting to released tags. Happy to submit the type-change variant as a follow-up if you'd prefer.