### PR TITLE
hw/xtensa/esp32s3: reset CPENABLE to 0xff to match silicon (QEMU-294)

### DIFF
--- a/hw/xtensa/esp32s3.c
+++ b/hw/xtensa/esp32s3.c
@@ -216,11 +216,21 @@ static void esp32s3_soc_reset(DeviceState *dev)
         xtensa_select_static_vectors(&s->cpu[0].env, s->rtc_cntl.stat_vector_sel[0]);
         remove_cpu_watchpoints(&s->cpu[0]);
         cpu_reset(CPU(&s->cpu[0]));
+        /* LX7 silicon resets CPENABLE to 0xff; the generic Xtensa CPU
+         * reset leaves it at the ISA default (0). Restore the vendor
+         * reset value so guest firmware that relies on it (e.g. any
+         * exception path spilling f0..f15 before establishing CPENABLE,
+         * including xtensa-lx-rt's float-save-restore handler) does
+         * not hang on the first FP instruction. Measured directly:
+         * `rsr.cpenable` as the first instruction in `main` reads
+         * 0xff on ESP32-S3 hardware, 0x00 under qemu-system-xtensa. */
+        s->cpu[0].env.sregs[CPENABLE] = 0xff;
     }
     if (s->requested_reset & ESP32S3_SOC_RESET_APPCPU && (ESP32S3_CPU_COUNT > 1)) {
         xtensa_select_static_vectors(&s->cpu[1].env, s->rtc_cntl.stat_vector_sel[1]);
         remove_cpu_watchpoints(&s->cpu[1]);
         cpu_reset(CPU(&s->cpu[1]));
+        s->cpu[1].env.sregs[CPENABLE] = 0xff;
     }
     s->requested_reset = 0;
 }


### PR DESCRIPTION
Fixes #154.

ESP32-S3 (LX7) silicon resets `CPENABLE` to `0xff` — directly
measured on ESP32-S3 with `rsr.cpenable` as the first instruction
in `main` (`0xff` on hardware, `0x00` under
`esp-develop-9.2.2-20260417`).

`xtensa_cpu_reset_hold` already writes `CPENABLE = 0xff`, but only in
the `CONFIG_USER_ONLY` branch, so `qemu-system-xtensa` boots with the
ISA default of `0`. Guest firmware that assumes the silicon contract
hangs on the first floating-point instruction — `Cp0Disabled` (cause
32) re-raises through the user-exception vector, which itself spills
`f0..f15` before CPENABLE is set (this is what `xtensa-lx-rt 0.21`
with `float-save-restore` does; that path is enabled by default in
`esp-hal 1.0`).

### Approach

Rather than make the unconditional change in `target/xtensa/cpu.c`
— which would change the reset value for the upstream
`sim`/`xtfpga`/`virt` Xtensa boards too — this patch writes the
vendor reset value right after `cpu_reset()` in the ESP32-S3 SoC
reset handler (`esp32s3_soc_reset`). Scope is limited to the chip
where the silicon value has been directly measured.

ESP32 (LX6, `hw/xtensa/esp32.c`) and ESP32-S2 almost certainly behave
the same way — `xtensa_cpu_reset_hold`'s user-mode branch sets
`0xff` unconditionally and the Espressif toolchain assumes it — but
I have not directly measured `rsr.cpenable` after reset on those
chips yet. The same one-line write should be added under each
corresponding `cpu_reset()` once that's confirmed. (`hw/xtensa/esp32s2.c`
does not exist in this fork today.)

### Verification

Against the minimal repro in #154, the FP loop now completes instead
of hanging silently. No change for guest binaries that already set
`CPENABLE` explicitly.
