### PR TITLE
hw/ssi/esp32s3_spi.c: Fix missing CS0_DIS and CS1_DIS default values … (QEMU-299)

### DIFF
--- a/hw/ssi/esp32s3_spi.c
+++ b/hw/ssi/esp32s3_spi.c
@@ -457,6 +457,10 @@ static void esp32s3_spi_reset_hold(Object *obj, ResetType type)
 {
     ESP32S3SpiState *s = ESP32S3_SPI(obj);
     memset(s->data_reg, 0, ESP32S3_SPI_BUF_WORDS * sizeof(uint32_t));
+
+    s->misc = FIELD_DP32(s->misc, SPI_MEM_MISC, CS0_DIS, 0);
+    s->misc = FIELD_DP32(s->misc, SPI_MEM_MISC, CS1_DIS, 1);
+
     s->mem_ctrl1 = FIELD_DP32(s->mem_ctrl1, SPI_MEM_CTRL1, CS_HOLD_DLY_RES, 0x3ff);
     s->mem_clock = FIELD_DP32(s->mem_clock, SPI_MEM_CLOCK, CLKCNT_N, 3);
     s->mem_clock = FIELD_DP32(s->mem_clock, SPI_MEM_CLOCK, CLKCNT_H, 1);


### PR DESCRIPTION
…in SPI_MEM_MISC

## Description

Added missing default values for CS0_DIS and CS1_DIS in the SPI_MEM_MISC register in esp32s3_spi_reset_hold. Without these initialisations, both the emulated PSRAM and flash devices would be selected simultaneously until the chip select bits are explicitly set to a different state. When both devices respond on the bus, the transferred data may become corrupted.

## Related

Fixes #159 - ESP32-S3: application image check sum failure after first boot with flash encryption enabled (QEMU-298)

## Checklist

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.