### PR TITLE
hw/ssi/esp32s3_spi: count dummy cycles across the data lines in use (QEMU-316)

### DIFF
--- a/hw/ssi/esp32s3_spi.c
+++ b/hw/ssi/esp32s3_spi.c
@@ -212,18 +212,25 @@ static inline void esp32s3_spi_get_addr(ESP32S3SpiState *s, uint32_t* addr, uint
 
 static inline void esp32s3_spi_get_dummy(ESP32S3SpiState *s, uint32_t* len)
 {
-    const uint32_t dummy_count = FIELD_EX32(s->mem_user1, SPI_MEM_USER1, USR_DUMMY_CYCLELEN);
+    /* The field holds the cycle count minus one (TRM: SPI_MEM_USR_DUMMY_CYCLELEN). */
+    const uint32_t cycles = FIELD_EX32(s->mem_user1, SPI_MEM_USER1, USR_DUMMY_CYCLELEN) + 1;
 
-    /* Dummy cycles are interpreted as bytes by the emulated SPI Flash. As such, we shall convert
-     * our dummy cycles count in bytes, rounding it up. For example:
-     * 0 cycles = 0 byte
-     * 1 cycle = 1 byte
-     * ...
-     * 8 cycles = 1 byte
-     * 9 cycles = 2 bytes
-     * etc..
-     */
-    *len = (dummy_count + 7) / 8;
+    /* The emulated SPI flash counts the dummy phase in bytes, so the cycles have
+     * to be converted with the number of data lines they run on. In the quad and
+     * dual I/O read modes (FREAD_QIO, FREAD_DIO) the address and dummy phases
+     * use four or two lines, so a cycle carries four or two bits: the 6 dummy
+     * cycles of a quad I/O read (0xEB) are 24 bits, the 3 bytes an ISSI part
+     * expects before it starts returning data. Counting every cycle as one bit
+     * sent a single byte there, the flash then consumed the first two data
+     * clocks as dummies, and every byte the guest read back arrived two
+     * positions late. */
+    uint32_t lanes = 1;
+    if (FIELD_EX32(s->mem_ctrl, SPI_MEM_CTRL, FREAD_QIO)) {
+        lanes = 4;
+    } else if (FIELD_EX32(s->mem_ctrl, SPI_MEM_CTRL, FREAD_DIO)) {
+        lanes = 2;
+    }
+    *len = (cycles * lanes + 7) / 8;
 }
 
 static void esp32s3_spi_begin_transaction(ESP32S3SpiState *s)


### PR DESCRIPTION
Fixes the SPI1 dummy-phase length being computed as though every read used a
single data line, reported as #169.

`USR_DUMMY_CYCLELEN` counts SPI clock cycles and holds the count minus one. In
a multi-line read each cycle carries one bit per line — four on quad I/O
(`FREAD_QIO`), two on dual I/O (`FREAD_DIO`) — but the conversion to the byte
count the emulated flash expects divided by eight regardless, and used the raw
field without adding one.

A quad I/O read (`0xEB`) programs six dummy cycles, which is 24 bits: the
three bytes an ISSI part expects before it starts returning data. Counting
each cycle as one bit sent a single byte, so the flash consumed the first two
data clocks as dummy and every byte the guest read back arrived two positions
late.

The symptom is firmware that boots (the ROM loader uses a different path) and
then fails to read anything correctly out of flash at runtime — in our case a
LittleFS mount that saw corrupt data on every attempt.

Verified by comparing the bytes the flash model returned against the image on
disk, before and after. Carried locally against
`esp-develop-9.2.2-20260417` since, and applies unchanged to `esp-develop`.
